### PR TITLE
Remove new unnecessary keys from build artifacts

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -22,7 +22,7 @@ module.exports = {
             },
             {
                 test: /\/build\/contracts\/\w+\.json$/,
-                use: ['json-x-loader?exclude=unlinked_binary+networks.*.events+networks.*.links']
+                use: ['json-x-loader?exclude=unlinked_binary+networks.*.events+networks.*.links+bytecode+deployedBytecode+sourceMap+deployedSourceMap+source+sourcePath+ast+legacyAST']
             },
             {
                 test: /\/gas-stats.json$/,


### PR DESCRIPTION
This only removes the keys when bundling build artifacts using webpack. Cuts `gnosis-pm.min.js` from 8.39MiB down to 835KiB.

Keys were added to the JSON filter because Truffle has changed its build artifact output.